### PR TITLE
Add readme and changelog to sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ path = "pytermgui/__init__.py"
 include = [
     "/pytermgui",
     "/tests",
+    "README.md",
+    "CHANGELOG.md",
 ]
 
 [tool.hatch.metadata.hooks.fancy-pypi-readme]


### PR DESCRIPTION
I'm maintaining this package on conda-forge, and we build pytermgui from the sdist deployed on PyPI. Because hatch-pancy-pypi-redme is building the fancy readme from README.md and CHANGELOG.md during the build, we need those two files in the PyPI sdist as well.